### PR TITLE
Munchies endpoint / Yelp API

### DIFF
--- a/app/controllers/api/v1/munchies_controller.rb
+++ b/app/controllers/api/v1/munchies_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::MunchiesController < ApplicationController
     search_parameters = {
       origin: params[:start],
       destination: params[:end],
-      food: params[:food]
+      food_type: params[:food]
     }
     facade = MunchiesIndexFacade.new(search_parameters)
     render json: facade.full_response

--- a/app/controllers/api/v1/munchies_controller.rb
+++ b/app/controllers/api/v1/munchies_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::MunchiesController < ApplicationController
   def index
     search_parameters = {
-      start: params[:start],
-      end: params[:end],
+      origin: params[:start],
+      destination: params[:end],
       food: params[:food]
     }
     facade = MunchiesIndexFacade.new(search_parameters)

--- a/app/controllers/api/v1/munchies_controller.rb
+++ b/app/controllers/api/v1/munchies_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::MunchiesController < ApplicationController
+  def index
+    search_parameters = {
+      start: params[:start],
+      end: params[:end],
+      food: params[:food]
+    }
+    facade = MunchiesIndexFacade.new(search_parameters)
+    render json: facade.full_response
+  end
+end

--- a/app/facades/forecast_show_facade.rb
+++ b/app/facades/forecast_show_facade.rb
@@ -25,13 +25,13 @@ class ForecastShowFacade
 
   private
 
-  def google_geocoding_api
+  def google_api
     parameters = { location_string: @location_string }
-    @google_geocoding_api ||= ApiService::Google.new(parameters)
+    @google_api ||= ApiService::Google.new(parameters)
   end
   
   def api_location_hash
-    @api_location_hash ||= google_geocoding_api.geocoding_results
+    @api_location_hash ||= google_api.geocoding_results
   end
 
   def lat_lng_hash

--- a/app/facades/forecast_show_facade.rb
+++ b/app/facades/forecast_show_facade.rb
@@ -27,7 +27,7 @@ class ForecastShowFacade
 
   def google_geocoding_api
     parameters = { location_string: @location_string }
-    @google_geocoding_api ||= ApiService::GoogleGeocoding.new(parameters)
+    @google_geocoding_api ||= ApiService::Google.new(parameters)
   end
   
   def api_location_hash

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -1,0 +1,50 @@
+class MunchiesIndexFacade
+  def initialize(parameters = {})
+    @start = parameters[:start]
+    @end = parameters[:end]
+    @food = parameters[:food]
+  end
+
+  def full_response
+  #   parameters = {
+  #     api_location_hash: api_location_hash,
+  #     forecast_hash: forecast_hash
+  #   }
+  #   {
+  #     meta: Forecast::Metadata.new(parameters).data,
+  #     data: data
+  #   }
+  end
+
+  # def data
+  #   parameters = { forecast_hash: forecast_hash }
+  #   {
+  #     currently: Forecast::Current.new(parameters).data,
+  #     daily: Forecast::Daily.new(parameters).data.first(5),
+  #     hourly: Forecast::Hourly.new(parameters).data.first(8)
+  #   }
+  # end
+
+  # private
+
+  # def google_geocoding_api
+  #   parameters = { location_string: @location_string }
+  #   @google_geocoding_api ||= ApiService::GoogleGeocoding.new(parameters)
+  # end
+  
+  # def api_location_hash
+  #   @api_location_hash ||= google_geocoding_api.geocoding_results
+  # end
+
+  # def lat_lng_hash
+  #   @lat_lng_hash ||= api_location_hash[:results].first[:geometry][:location]
+  # end
+
+  # def dark_sky_api
+  #   @dark_sky_api ||= ApiService::DarkSky.new(lat_lng_hash)
+  # end
+
+  # def forecast_hash
+  #   @forecast_hash ||= dark_sky_api.forecast
+  # end
+end

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -14,13 +14,13 @@ class MunchiesIndexFacade
   
   private
   
-  def google_geocoding_api
+  def google_api
     parameters = { origin: @origin, destination: @destination }
-    @google_geocoding_api ||= ApiService::Google.new(parameters)
+    @google_api ||= ApiService::Google.new(parameters)
   end
   
   def api_directions_hash
-    @api_directions_hash ||= google_geocoding_api.directions
+    @api_directions_hash ||= google_api.directions
   end
 
   def duration_in_seconds

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -1,11 +1,13 @@
 class MunchiesIndexFacade
   def initialize(parameters = {})
-    @start = parameters[:start]
-    @end = parameters[:end]
+    @origin = parameters[:origin]
+    @destination = parameters[:destination]
     @food = parameters[:food]
   end
 
   def full_response
+    # TODO
+    duration
   #   parameters = {
   #     api_location_hash: api_location_hash,
   #     forecast_hash: forecast_hash
@@ -16,35 +18,19 @@ class MunchiesIndexFacade
   #   }
   end
 
-  # def data
-  #   parameters = { forecast_hash: forecast_hash }
-  #   {
-  #     currently: Forecast::Current.new(parameters).data,
-  #     daily: Forecast::Daily.new(parameters).data.first(5),
-  #     hourly: Forecast::Hourly.new(parameters).data.first(8)
-  #   }
-  # end
+  def duration
+    api_directions_hash
+    require 'pry'; binding.pry
+  end
 
-  # private
+  private
 
-  # def google_geocoding_api
-  #   parameters = { location_string: @location_string }
-  #   @google_geocoding_api ||= ApiService::GoogleGeocoding.new(parameters)
-  # end
+  def google_geocoding_api
+    parameters = { origin: @origin, destination: @destination }
+    @google_geocoding_api ||= ApiService::GoogleGeocoding.new(parameters)
+  end
   
-  # def api_location_hash
-  #   @api_location_hash ||= google_geocoding_api.geocoding_results
-  # end
-
-  # def lat_lng_hash
-  #   @lat_lng_hash ||= api_location_hash[:results].first[:geometry][:location]
-  # end
-
-  # def dark_sky_api
-  #   @dark_sky_api ||= ApiService::DarkSky.new(lat_lng_hash)
-  # end
-
-  # def forecast_hash
-  #   @forecast_hash ||= dark_sky_api.forecast
-  # end
+  def api_directions_hash
+    @api_directions_hash ||= google_geocoding_api.directions
+  end
 end

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -7,7 +7,8 @@ class MunchiesIndexFacade
 
   def full_response
     # TODO
-    duration
+    arrival_epoch
+    require 'pry'; binding.pry
   #   parameters = {
   #     api_location_hash: api_location_hash,
   #     forecast_hash: forecast_hash
@@ -18,9 +19,12 @@ class MunchiesIndexFacade
   #   }
   end
 
-  def duration
-    api_directions_hash
-    require 'pry'; binding.pry
+  def duration_in_seconds
+    api_directions_hash[:routes].first[:legs].first[:duration][:value]
+  end
+
+  def arrival_epoch
+    Time.now.to_i + duration_in_seconds
   end
 
   private

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -7,7 +7,7 @@ class MunchiesIndexFacade
 
   def full_response
     {
-      meta: { location: city_and_state },
+      meta: { location: destination_city_and_state },
       data: { restaurants: restaurants }
     }
   end
@@ -53,10 +53,10 @@ class MunchiesIndexFacade
     end
   end
 
-  def city_and_state
+  def destination_city_and_state
     first_restaurant = api_restaurants_hash[:businesses].first
     city = first_restaurant[:location][:city]
     state = first_restaurant[:location][:state]
-    {city: city, state: state}
+    { city: city, state: state }
   end
 end

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -6,17 +6,10 @@ class MunchiesIndexFacade
   end
 
   def full_response
-    # TODO
-    arrival_epoch
-    require 'pry'; binding.pry
-  #   parameters = {
-  #     api_location_hash: api_location_hash,
-  #     forecast_hash: forecast_hash
-  #   }
-  #   {
-  #     meta: Forecast::Metadata.new(parameters).data,
-  #     data: data
-  #   }
+    {
+      meta: { location: @destination },
+      data: { restaurants: restaurants }
+    }
   end
   
   private
@@ -36,5 +29,27 @@ class MunchiesIndexFacade
 
   def arrival_epoch
     Time.now.to_i + duration_in_seconds
+  end
+
+  def yelp_api
+    parameters = { 
+      location: @destination,
+      food_type: @food,
+      epoch: arrival_epoch
+    }
+    @yelp_api ||= ApiService::Yelp.new(parameters)
+  end
+  
+  def api_restaurants_hash
+    @api_restaurants_hash ||= yelp_api.restaurants
+  end
+
+  def restaurants
+    api_restaurants_hash[:businesses].first(3).map do |restaurant|
+      {
+        name: restaurant[:name],
+        address: restaurant[:location][:display_address]
+      }
+    end
   end
 end

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -7,7 +7,7 @@ class MunchiesIndexFacade
 
   def full_response
     {
-      meta: { location: @destination },
+      meta: { location: city_and_state },
       data: { restaurants: restaurants }
     }
   end
@@ -51,5 +51,12 @@ class MunchiesIndexFacade
         address: restaurant[:location][:display_address]
       }
     end
+  end
+
+  def city_and_state
+    first_restaurant = api_restaurants_hash[:businesses].first
+    city = first_restaurant[:location][:city]
+    state = first_restaurant[:location][:state]
+    {city: city, state: state}
   end
 end

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -2,7 +2,7 @@ class MunchiesIndexFacade
   def initialize(parameters = {})
     @origin = parameters[:origin]
     @destination = parameters[:destination]
-    @food = parameters[:food]
+    @food_type = parameters[:food_type]
   end
 
   def full_response
@@ -34,7 +34,7 @@ class MunchiesIndexFacade
   def yelp_api
     parameters = { 
       location: @destination,
-      food_type: @food,
+      food_type: @food_type,
       epoch: arrival_epoch
     }
     @yelp_api ||= ApiService::Yelp.new(parameters)

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -18,17 +18,9 @@ class MunchiesIndexFacade
   #     data: data
   #   }
   end
-
-  def duration_in_seconds
-    api_directions_hash[:routes].first[:legs].first[:duration][:value]
-  end
-
-  def arrival_epoch
-    Time.now.to_i + duration_in_seconds
-  end
-
+  
   private
-
+  
   def google_geocoding_api
     parameters = { origin: @origin, destination: @destination }
     @google_geocoding_api ||= ApiService::GoogleGeocoding.new(parameters)
@@ -36,5 +28,13 @@ class MunchiesIndexFacade
   
   def api_directions_hash
     @api_directions_hash ||= google_geocoding_api.directions
+  end
+
+  def duration_in_seconds
+    api_directions_hash[:routes].first[:legs].first[:duration][:value]
+  end
+
+  def arrival_epoch
+    Time.now.to_i + duration_in_seconds
   end
 end

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -16,7 +16,7 @@ class MunchiesIndexFacade
   
   def google_geocoding_api
     parameters = { origin: @origin, destination: @destination }
-    @google_geocoding_api ||= ApiService::GoogleGeocoding.new(parameters)
+    @google_geocoding_api ||= ApiService::Google.new(parameters)
   end
   
   def api_directions_hash

--- a/app/services/api_service/dark_sky.rb
+++ b/app/services/api_service/dark_sky.rb
@@ -9,7 +9,7 @@ class ApiService::DarkSky < ApiService::Base
   def forecast
     uri_path = "/forecast/#{ENV['DARK_SKY_API_KEY']}/#{@lat},#{@long}"
     forecast_hash = fetch_json_data(uri_path)
-    raise 'Bad Dark Sky API key' if forecast_hash[:error]
+    check_and_raise_error(forecast_hash)
     forecast_hash
   end
 
@@ -20,5 +20,10 @@ class ApiService::DarkSky < ApiService::Base
       faraday.adapter Faraday.default_adapter
       faraday.params['exclude'] = 'minutely'
     end
+  end
+
+  def check_and_raise_error(response)
+    error_message = response[:error]
+    raise "#{self.class} error: #{error_message}" if error_message
   end
 end

--- a/app/services/api_service/flickr.rb
+++ b/app/services/api_service/flickr.rb
@@ -35,7 +35,7 @@ class ApiService::Flickr < ApiService::Base
       text: @location_string,
       sort: 'relevance',
       content: 'relevance',
-      per_page: 5 # TODO: change to 1
+      per_page: 1
     }
     response = fetch_xml_data(uri_path, search_parameters)
     raise 'Bad Flickr API key' if bad_api_key?(response)

--- a/app/services/api_service/google.rb
+++ b/app/services/api_service/google.rb
@@ -1,5 +1,4 @@
-# TODO: rename to be just Google
-class ApiService::GoogleGeocoding < ApiService::Base
+class ApiService::Google < ApiService::Base
   attr_reader :location_string, :origin, :destination
 
   def initialize(parameters = {})

--- a/app/services/api_service/google.rb
+++ b/app/services/api_service/google.rb
@@ -10,7 +10,7 @@ class ApiService::Google < ApiService::Base
   def geocoding_results
     uri_path = '/maps/api/geocode/json'
     location_hash = fetch_json_data(uri_path, address: @location_string)
-    raise 'Bad Google Maps API key' if location_hash[:error_message]
+    check_and_raise_error(location_hash)
     location_hash
   end
   
@@ -18,8 +18,7 @@ class ApiService::Google < ApiService::Base
     uri_path = '/maps/api/directions/json'
     parameters = { origin: @origin, destination: @destination }
     directions_hash = fetch_json_data(uri_path, parameters)
-    # TODO: change exception message be the actual error, similar for others
-    raise 'Bad Google Maps API key' if directions_hash[:error_message]
+    check_and_raise_error(directions_hash)
     directions_hash
   end
 
@@ -30,5 +29,10 @@ class ApiService::Google < ApiService::Base
       faraday.adapter Faraday.default_adapter
       faraday.params['key'] = ENV['GOOGLE_MAPS_API_KEY']
     end
+  end
+
+  def check_and_raise_error(response)
+    error_message = response[:error_message]
+    raise "#{self.class} error: #{error_message}" if error_message
   end
 end

--- a/app/services/api_service/google_geocoding.rb
+++ b/app/services/api_service/google_geocoding.rb
@@ -1,8 +1,11 @@
+# TODO: rename to be just Google
 class ApiService::GoogleGeocoding < ApiService::Base
-  attr_reader :location_string
+  attr_reader :location_string, :origin, :destination
 
   def initialize(parameters = {})
     @location_string = parameters[:location_string]
+    @origin = parameters[:origin]
+    @destination = parameters[:destination]
   end
 
   def geocoding_results
@@ -10,6 +13,16 @@ class ApiService::GoogleGeocoding < ApiService::Base
     location_hash = fetch_json_data(uri_path, address: @location_string)
     raise 'Bad Google Maps API key' if location_hash[:error_message]
     location_hash
+  end
+  
+  def directions
+    uri_path = '/maps/api/directions/json'
+    parameters = { origin: @origin, destination: @destination }
+    directions_hash = fetch_json_data(uri_path, parameters)
+    # TODO: change exception message be the actual error
+    raise 'Bad Google Maps API key' if directions_hash[:error_message]
+    directions_hash
+    require 'pry'; binding.pry
   end
 
   private

--- a/app/services/api_service/google_geocoding.rb
+++ b/app/services/api_service/google_geocoding.rb
@@ -19,7 +19,7 @@ class ApiService::GoogleGeocoding < ApiService::Base
     uri_path = '/maps/api/directions/json'
     parameters = { origin: @origin, destination: @destination }
     directions_hash = fetch_json_data(uri_path, parameters)
-    # TODO: change exception message be the actual error
+    # TODO: change exception message be the actual error, similar for others
     raise 'Bad Google Maps API key' if directions_hash[:error_message]
     directions_hash
   end

--- a/app/services/api_service/google_geocoding.rb
+++ b/app/services/api_service/google_geocoding.rb
@@ -22,7 +22,6 @@ class ApiService::GoogleGeocoding < ApiService::Base
     # TODO: change exception message be the actual error
     raise 'Bad Google Maps API key' if directions_hash[:error_message]
     directions_hash
-    require 'pry'; binding.pry
   end
 
   private

--- a/app/services/api_service/yelp.rb
+++ b/app/services/api_service/yelp.rb
@@ -16,7 +16,7 @@ class ApiService::Yelp < ApiService::Base
       open_at: @epoch
     }
     restaurants_hash = fetch_json_data(uri_path, search_parameters)
-    raise 'Bad Yelp API key' if restaurants_hash[:error]
+    check_and_raise_error(restaurants_hash)
     restaurants_hash
   end
 
@@ -27,5 +27,10 @@ class ApiService::Yelp < ApiService::Base
       faraday.adapter Faraday.default_adapter
       faraday.headers['Authorization'] = "Bearer #{ENV['YELP_API_KEY']}"
     end
+  end
+
+  def check_and_raise_error(response)
+    error_message = response[:error]
+    raise "#{self.class} error: #{error_message}" if error_message
   end
 end

--- a/app/services/api_service/yelp.rb
+++ b/app/services/api_service/yelp.rb
@@ -15,9 +15,9 @@ class ApiService::Yelp < ApiService::Base
       categories: 'food',
       open_at: @epoch
     }
-    forecast_hash = fetch_json_data(uri_path, search_parameters)
-    raise 'Bad Yelp API key' if forecast_hash[:error]
-    forecast_hash
+    restaurants_hash = fetch_json_data(uri_path, search_parameters)
+    raise 'Bad Yelp API key' if restaurants_hash[:error]
+    restaurants_hash
   end
 
   private

--- a/app/services/api_service/yelp.rb
+++ b/app/services/api_service/yelp.rb
@@ -1,0 +1,24 @@
+class ApiService::Yelp < ApiService::Base
+  # attr_reader :lat, :long
+
+  # def initialize(parameters = {})
+  #   @lat = parameters[:lat]
+  #   @long = parameters[:lng]
+  # end
+
+  # def forecast
+  #   uri_path = '/v3/businesses/search'
+  #   forecast_hash = fetch_json_data(uri_path, location: something)
+  #   raise 'Bad Yelp API key' if forecast_hash[:error]
+  #   forecast_hash
+  # end
+
+  private
+
+  def conn
+    @conn ||= Faraday.new(:url => 'https://api.yelp.com') do |faraday|
+      faraday.adapter Faraday.default_adapter
+      faraday.headers['Authorization'] = "Bearer #{ENV['YELP_API_KEY']}"
+    end
+  end
+end

--- a/app/services/api_service/yelp.rb
+++ b/app/services/api_service/yelp.rb
@@ -1,17 +1,24 @@
 class ApiService::Yelp < ApiService::Base
-  # attr_reader :lat, :long
+  attr_reader :location, :food_type, :epoch
 
-  # def initialize(parameters = {})
-  #   @lat = parameters[:lat]
-  #   @long = parameters[:lng]
-  # end
+  def initialize(parameters = {})
+    @location = parameters[:location]
+    @food_type = parameters[:food_type]
+    @epoch = parameters[:epoch]
+  end
 
-  # def forecast
-  #   uri_path = '/v3/businesses/search'
-  #   forecast_hash = fetch_json_data(uri_path, location: something)
-  #   raise 'Bad Yelp API key' if forecast_hash[:error]
-  #   forecast_hash
-  # end
+  def restaurants
+    uri_path = '/v3/businesses/search'
+    search_parameters = {
+      location: @location,
+      term: @food_type,
+      categories: 'food',
+      open_at: @epoch
+    }
+    forecast_hash = fetch_json_data(uri_path, search_parameters)
+    raise 'Bad Yelp API key' if forecast_hash[:error]
+    forecast_hash
+  end
 
   private
 

--- a/app/services/forecast/daily.rb
+++ b/app/services/forecast/daily.rb
@@ -6,7 +6,8 @@ class Forecast::Daily < Forecast::Base
         low_temperature: api_data_for_day[:temperatureLow],
         summary: api_data_for_day[:summary],
         day_of_week: day_of_week(api_data_for_day[:time]),
-        type: api_data_for_day[:icon], # TODO
+        # TODO - delete type? not returned by the API for daily
+        type: api_data_for_day[:icon],
         icon: api_data_for_day[:icon],
         chance_of_precip: api_data_for_day[:precipProbability],
         precip_type: api_data_for_day[:precipType]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       get 'forecast', to: 'forecasts#show'
       get 'backgrounds', to: 'backgrounds#show'
+      get 'munchies', to: 'munchies#index'
     end
   end
 end

--- a/spec/requests/api/v1/munchies_spec.rb
+++ b/spec/requests/api/v1/munchies_spec.rb
@@ -9,38 +9,19 @@ describe "Munchies Endpoint" do
     expect(response).to be_successful
   end
 
-  # You will use the Google Directions API: https://developers.google.com/maps/documentation/directions/start in order to find out how long it will take to travel from the two locations, and then using the Yelp API, you will find all of the restaurants matching the cuisine, the example here is Chinese, that WILL BE OPEN at your estimated time of arrival.
-  
-  # Your API will return the end city, and three restaurants, along with their name and address.
-  
-  # The Yelp API only accepts time as UNIX time. You can conert a Time object into UNIX time by doing something like this: Time.now.to_i
-  # You can find out time in the future using a feature built into Rails' ActiveSupport which will let you do things like this: Time.now + 4.hours (This will ONLY work in Rails and not a pry session run from the command line)
-  
-  # it "response includes query details" do
-  #   meta = JSON.parse(response.body, symbolize_names: true)[:meta]
-  
-  #   expect(meta).to have_key(:time)
-  #   expect(meta).to have_key(:date)
-  
-  #   expect(meta[:location]).to have_key(:city)
-  #   expect(meta[:location]).to have_key(:state)
-  #   expect(meta[:location]).to have_key(:country)
-  
-  #   expect(meta[:data_source]).to have_key(:message)
-  #   expect(meta[:data_source]).to have_key(:link)
-  # end
-  
-  # it "response includes current weather info" do
-  #   json_response = JSON.parse(response.body, symbolize_names: true)
-  #   current_weather = json_response[:data][:currently]
-  
-  #   expect(current_weather).to have_key(:type)
-  #   expect(current_weather).to have_key(:icon)
-  #   expect(current_weather).to have_key(:temperature)
-  #   expect(current_weather).to have_key(:feels_like)
-  #   expect(current_weather).to have_key(:humidity)
-  #   expect(current_weather).to have_key(:visibility)
-  #   expect(current_weather).to have_key(:uv_index_number)
-  #   expect(current_weather).to have_key(:uv_index_intensity)
-  # end
+  it "returns the end city" do
+    meta = JSON.parse(response.body, symbolize_names: true)[:meta]
+
+    expect(meta).to have_key(:location)
+  end
+
+  it 'returns info for 3 restaurants that will be open upon arrival at the destination' do
+    json_response = JSON.parse(response.body, symbolize_names: true)
+    restaurants = json_response[:data][:restaurants]
+
+    expect(restaurants).to be_an(Array)
+    expect(restaurants.count).to eq(3)
+    expect(restaurants.first).to have_key(:name)
+    expect(restaurants.first).to have_key(:address)
+  end
 end

--- a/spec/requests/api/v1/munchies_spec.rb
+++ b/spec/requests/api/v1/munchies_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe "Munchies Endpoint" do
+  before(:each) do
+    get '/api/v1/munchies?start=denver,co&end=pueblo,co&food=chinese'
+  end
+  
+  it "gets back a good response" do
+    expect(response).to be_successful
+  end
+
+  # You will use the Google Directions API: https://developers.google.com/maps/documentation/directions/start in order to find out how long it will take to travel from the two locations, and then using the Yelp API, you will find all of the restaurants matching the cuisine, the example here is Chinese, that WILL BE OPEN at your estimated time of arrival.
+  
+  # Your API will return the end city, and three restaurants, along with their name and address.
+  
+  # The Yelp API only accepts time as UNIX time. You can conert a Time object into UNIX time by doing something like this: Time.now.to_i
+  # You can find out time in the future using a feature built into Rails' ActiveSupport which will let you do things like this: Time.now + 4.hours (This will ONLY work in Rails and not a pry session run from the command line)
+  
+  # it "response includes query details" do
+  #   meta = JSON.parse(response.body, symbolize_names: true)[:meta]
+  
+  #   expect(meta).to have_key(:time)
+  #   expect(meta).to have_key(:date)
+  
+  #   expect(meta[:location]).to have_key(:city)
+  #   expect(meta[:location]).to have_key(:state)
+  #   expect(meta[:location]).to have_key(:country)
+  
+  #   expect(meta[:data_source]).to have_key(:message)
+  #   expect(meta[:data_source]).to have_key(:link)
+  # end
+  
+  # it "response includes current weather info" do
+  #   json_response = JSON.parse(response.body, symbolize_names: true)
+  #   current_weather = json_response[:data][:currently]
+  
+  #   expect(current_weather).to have_key(:type)
+  #   expect(current_weather).to have_key(:icon)
+  #   expect(current_weather).to have_key(:temperature)
+  #   expect(current_weather).to have_key(:feels_like)
+  #   expect(current_weather).to have_key(:humidity)
+  #   expect(current_weather).to have_key(:visibility)
+  #   expect(current_weather).to have_key(:uv_index_number)
+  #   expect(current_weather).to have_key(:uv_index_intensity)
+  # end
+end

--- a/spec/requests/api/v1/munchies_spec.rb
+++ b/spec/requests/api/v1/munchies_spec.rb
@@ -9,10 +9,11 @@ describe "Munchies Endpoint" do
     expect(response).to be_successful
   end
 
-  it "returns the end city" do
+  it "returns the endpoint city & state" do
     meta = JSON.parse(response.body, symbolize_names: true)[:meta]
 
-    expect(meta).to have_key(:location)
+    expect(meta[:location]).to have_key(:city)
+    expect(meta[:location]).to have_key(:state)
   end
 
   it 'returns info for 3 restaurants that will be open upon arrival at the destination' do

--- a/spec/services/api_service/dark_sky_spec.rb
+++ b/spec/services/api_service/dark_sky_spec.rb
@@ -52,6 +52,6 @@ describe ApiService::DarkSky do
 
     stub_const('ENV', {'DARK_SKY_API_KEY' => 'blah'})
 
-    expect { service.forecast }.to raise_error('Bad Dark Sky API key')
+    expect { service.forecast }.to raise_error('ApiService::DarkSky error: permission denied')
   end
 end

--- a/spec/services/api_service/dark_sky_spec.rb
+++ b/spec/services/api_service/dark_sky_spec.rb
@@ -38,7 +38,9 @@ describe ApiService::DarkSky do
     expect(result[:daily][:data].first).to have_key(:time)
     expect(result[:daily][:data].first).to have_key(:icon)
     expect(result[:daily][:data].first).to have_key(:summary)
-    expect(result[:daily][:data].first).to have_key(:precipType)
+    # TODO: delete precipType from here & facade?
+    # The API is not including it on Monday
+    # expect(result[:daily][:data].first).to have_key(:precipType)
     expect(result[:daily][:data].first).to have_key(:precipProbability)
     expect(result[:daily][:data].first).to have_key(:temperatureHigh)
     expect(result[:daily][:data].first).to have_key(:temperatureLow)

--- a/spec/services/api_service/google_geocoding_spec.rb
+++ b/spec/services/api_service/google_geocoding_spec.rb
@@ -35,4 +35,25 @@ describe ApiService::GoogleGeocoding do
 
     expect { service.geocoding_results }.to raise_error('Bad Google Maps API key')
   end
+  
+  it '#directions returns directions info from origin to destination' do
+    origin = 'denver, co'
+    destination = 'pueblo, co'
+    service = ApiService::GoogleGeocoding.new({ origin: origin, destination: destination })
+    result = service.directions
+    
+    expect(result[:routes]).to be_an(Array)
+    expect(result[:routes].first[:legs]).to be_an(Array)
+    expect(result[:routes].first[:legs].first[:duration]).to have_key(:text)
+  end
+  
+  it '#directions raises an error if the API response is bad' do
+    origin = 'denver, co'
+    destination = 'pueblo, co'
+    service = ApiService::GoogleGeocoding.new({ origin: origin, destination: destination })
+    
+    stub_const('ENV', {'GOOGLE_MAPS_API_KEY' => 'blah'})
+
+    expect { service.directions }.to raise_error('Bad Google Maps API key')
+  end
 end

--- a/spec/services/api_service/google_geocoding_spec.rb
+++ b/spec/services/api_service/google_geocoding_spec.rb
@@ -5,10 +5,16 @@ describe ApiService::GoogleGeocoding do
     expect(subject).to be_a(ApiService::GoogleGeocoding)
   end
 
-  it 'initializes with location_string' do
+  it 'initializes with location_string, origin, and/or destination' do
     location_string = 'denver, co'
-    service = ApiService::GoogleGeocoding.new({ location_string: location_string })
-    expect(service.location_string).to eq(location_string)
+    service1 = ApiService::GoogleGeocoding.new({ location_string: location_string })
+    expect(service1.location_string).to eq(location_string)
+
+    origin = 'denver, co'
+    destination = 'pueblo, co'
+    service2 = ApiService::GoogleGeocoding.new({ origin: origin, destination: destination })
+    expect(service2.origin).to eq(origin)
+    expect(service2.destination).to eq(destination)
   end
   
   it '#geocoding_results returns formatted location and lat/long' do

--- a/spec/services/api_service/google_spec.rb
+++ b/spec/services/api_service/google_spec.rb
@@ -1,25 +1,25 @@
 require 'rails_helper'
 
-describe ApiService::GoogleGeocoding do
+describe ApiService::Google do
   it 'exists' do
-    expect(subject).to be_a(ApiService::GoogleGeocoding)
+    expect(subject).to be_a(ApiService::Google)
   end
 
   it 'initializes with location_string, origin, and/or destination' do
     location_string = 'denver, co'
-    service1 = ApiService::GoogleGeocoding.new({ location_string: location_string })
+    service1 = ApiService::Google.new({ location_string: location_string })
     expect(service1.location_string).to eq(location_string)
 
     origin = 'denver, co'
     destination = 'pueblo, co'
-    service2 = ApiService::GoogleGeocoding.new({ origin: origin, destination: destination })
+    service2 = ApiService::Google.new({ origin: origin, destination: destination })
     expect(service2.origin).to eq(origin)
     expect(service2.destination).to eq(destination)
   end
   
   it '#geocoding_results returns formatted location and lat/long' do
     location_string = 'denver, co'
-    service = ApiService::GoogleGeocoding.new({ location_string: location_string })
+    service = ApiService::Google.new({ location_string: location_string })
     result = service.geocoding_results
     
     expect(result).to have_key(:results)
@@ -29,7 +29,7 @@ describe ApiService::GoogleGeocoding do
   end
   
   it '#geocoding_results raises an error if the API response is bad' do
-    service = ApiService::GoogleGeocoding.new({ location_string: 'denver, co' })
+    service = ApiService::Google.new({ location_string: 'denver, co' })
 
     stub_const('ENV', {'GOOGLE_MAPS_API_KEY' => 'blah'})
 
@@ -39,7 +39,7 @@ describe ApiService::GoogleGeocoding do
   it '#directions returns directions info from origin to destination' do
     origin = 'denver, co'
     destination = 'pueblo, co'
-    service = ApiService::GoogleGeocoding.new({ origin: origin, destination: destination })
+    service = ApiService::Google.new({ origin: origin, destination: destination })
     result = service.directions
     
     expect(result[:routes]).to be_an(Array)
@@ -50,7 +50,7 @@ describe ApiService::GoogleGeocoding do
   it '#directions raises an error if the API response is bad' do
     origin = 'denver, co'
     destination = 'pueblo, co'
-    service = ApiService::GoogleGeocoding.new({ origin: origin, destination: destination })
+    service = ApiService::Google.new({ origin: origin, destination: destination })
     
     stub_const('ENV', {'GOOGLE_MAPS_API_KEY' => 'blah'})
 

--- a/spec/services/api_service/google_spec.rb
+++ b/spec/services/api_service/google_spec.rb
@@ -33,7 +33,7 @@ describe ApiService::Google do
 
     stub_const('ENV', {'GOOGLE_MAPS_API_KEY' => 'blah'})
 
-    expect { service.geocoding_results }.to raise_error('Bad Google Maps API key')
+    expect { service.geocoding_results }.to raise_error('ApiService::Google error: The provided API key is invalid.')
   end
   
   it '#directions returns directions info from origin to destination' do
@@ -54,6 +54,6 @@ describe ApiService::Google do
     
     stub_const('ENV', {'GOOGLE_MAPS_API_KEY' => 'blah'})
 
-    expect { service.directions }.to raise_error('Bad Google Maps API key')
+    expect { service.directions }.to raise_error('ApiService::Google error: The provided API key is invalid.')
   end
 end

--- a/spec/services/api_service/yelp_spec.rb
+++ b/spec/services/api_service/yelp_spec.rb
@@ -43,6 +43,6 @@ describe ApiService::Yelp do
 
     stub_const('ENV', {'YELP_API_KEY' => 'blah'})
 
-    expect { service.restaurants }.to raise_error('Bad Yelp API key')
+    expect { service.restaurants }.to raise_error(RuntimeError)
   end
 end

--- a/spec/services/api_service/yelp_spec.rb
+++ b/spec/services/api_service/yelp_spec.rb
@@ -5,51 +5,44 @@ describe ApiService::Yelp do
     expect(subject).to be_a(ApiService::Yelp)
   end
 
-  # it 'initializes with location_string' do
-  #   lat_lng_hash = { lat: 37.8267, lng: -122.4233 }
-  #   service = ApiService::Yelp.new(lat_lng_hash)
+  it 'initializes with location, food_type, and epoch' do
+    parameters = { 
+      location: 'pueblo, co',
+      food_type: 'chinese',
+      epoch: 1564421959
+    }
+    service = ApiService::Yelp.new(parameters)
     
-  #   expect(service.lat).to eq(lat_lng_hash[:lat])
-  #   expect(service.long).to eq(lat_lng_hash[:lng])
-  # end
+    expect(service.location).to eq(parameters[:location])
+    expect(service.food_type).to eq(parameters[:food_type])
+    expect(service.epoch).to eq(parameters[:epoch])
+  end
   
-  # it '#forecast returns forecasted data' do
-  #   lat_lng_hash = { lat: 37.8267, lng: -122.4233 }
-  #   service = ApiService::Yelp.new(lat_lng_hash)
-  #   result = service.forecast
+  it '#restaurants returns data for many restaurants' do
+    parameters = { 
+      location: 'pueblo, co',
+      food_type: 'chinese',
+      epoch: 1564421959
+    }
+    service = ApiService::Yelp.new(parameters)
+    result = service.restaurants
     
-  #   expect(result).to have_key(:offset) # UTC offset
-
-  #   expect(result[:currently]).to have_key(:time)
-  #   expect(result[:currently]).to have_key(:summary)
-  #   expect(result[:currently]).to have_key(:icon)
-  #   expect(result[:currently]).to have_key(:temperature)
-  #   expect(result[:currently]).to have_key(:apparentTemperature)
-  #   expect(result[:currently]).to have_key(:humidity)
-  #   expect(result[:currently]).to have_key(:visibility)
-  #   expect(result[:currently]).to have_key(:uvIndex)
-    
-  #   expect(result[:hourly][:data].count).to be >= 8
-  #   expect(result[:hourly][:data].first).to have_key(:time)
-  #   expect(result[:hourly][:data].first).to have_key(:icon)
-  #   expect(result[:hourly][:data].first).to have_key(:temperature)
-    
-  #   expect(result[:daily][:data].count).to be >= 5
-  #   expect(result[:daily][:data].first).to have_key(:time)
-  #   expect(result[:daily][:data].first).to have_key(:icon)
-  #   expect(result[:daily][:data].first).to have_key(:summary)
-  #   expect(result[:daily][:data].first).to have_key(:precipType)
-  #   expect(result[:daily][:data].first).to have_key(:precipProbability)
-  #   expect(result[:daily][:data].first).to have_key(:temperatureHigh)
-  #   expect(result[:daily][:data].first).to have_key(:temperatureLow)
-  # end
+    expect(result[:businesses]).to be_an(Array)
+    expect(result[:businesses].count).to be >= 3
+    expect(result[:businesses].first).to have_key(:name)
+    expect(result[:businesses].first[:location]).to have_key(:display_address)
+  end
   
-  # it '#forecast raises an error if the API response is bad' do
-  #   lat_lng_hash = { lat: 37.8267, lng: -122.4233 }
-  #   service = ApiService::Yelp.new(lat_lng_hash)
+  it '#restaurants raises an error if the API response is bad' do
+    parameters = { 
+      location: 'pueblo, co',
+      food_type: 'chinese',
+      epoch: 1564421959
+    }
+    service = ApiService::Yelp.new(parameters)
 
-  #   stub_const('ENV', {'YELP_API_KEY' => 'blah'})
+    stub_const('ENV', {'YELP_API_KEY' => 'blah'})
 
-  #   expect { service.forecast }.to raise_error('Bad Dark Sky API key')
-  # end
+    expect { service.restaurants }.to raise_error('Bad Yelp API key')
+  end
 end

--- a/spec/services/api_service/yelp_spec.rb
+++ b/spec/services/api_service/yelp_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe ApiService::Yelp do
+  it 'exists' do
+    expect(subject).to be_a(ApiService::Yelp)
+  end
+
+  # it 'initializes with location_string' do
+  #   lat_lng_hash = { lat: 37.8267, lng: -122.4233 }
+  #   service = ApiService::Yelp.new(lat_lng_hash)
+    
+  #   expect(service.lat).to eq(lat_lng_hash[:lat])
+  #   expect(service.long).to eq(lat_lng_hash[:lng])
+  # end
+  
+  # it '#forecast returns forecasted data' do
+  #   lat_lng_hash = { lat: 37.8267, lng: -122.4233 }
+  #   service = ApiService::Yelp.new(lat_lng_hash)
+  #   result = service.forecast
+    
+  #   expect(result).to have_key(:offset) # UTC offset
+
+  #   expect(result[:currently]).to have_key(:time)
+  #   expect(result[:currently]).to have_key(:summary)
+  #   expect(result[:currently]).to have_key(:icon)
+  #   expect(result[:currently]).to have_key(:temperature)
+  #   expect(result[:currently]).to have_key(:apparentTemperature)
+  #   expect(result[:currently]).to have_key(:humidity)
+  #   expect(result[:currently]).to have_key(:visibility)
+  #   expect(result[:currently]).to have_key(:uvIndex)
+    
+  #   expect(result[:hourly][:data].count).to be >= 8
+  #   expect(result[:hourly][:data].first).to have_key(:time)
+  #   expect(result[:hourly][:data].first).to have_key(:icon)
+  #   expect(result[:hourly][:data].first).to have_key(:temperature)
+    
+  #   expect(result[:daily][:data].count).to be >= 5
+  #   expect(result[:daily][:data].first).to have_key(:time)
+  #   expect(result[:daily][:data].first).to have_key(:icon)
+  #   expect(result[:daily][:data].first).to have_key(:summary)
+  #   expect(result[:daily][:data].first).to have_key(:precipType)
+  #   expect(result[:daily][:data].first).to have_key(:precipProbability)
+  #   expect(result[:daily][:data].first).to have_key(:temperatureHigh)
+  #   expect(result[:daily][:data].first).to have_key(:temperatureLow)
+  # end
+  
+  # it '#forecast raises an error if the API response is bad' do
+  #   lat_lng_hash = { lat: 37.8267, lng: -122.4233 }
+  #   service = ApiService::Yelp.new(lat_lng_hash)
+
+  #   stub_const('ENV', {'YELP_API_KEY' => 'blah'})
+
+  #   expect { service.forecast }.to raise_error('Bad Dark Sky API key')
+  # end
+end


### PR DESCRIPTION
This branch...
 - `get /api/v1/munchies` endpoint returns information about 3 restaurants at the destination that will be open when you arrive (resolves #17)
 - Adds `Api::V1::MunchiesController#index` & `MunchiesIndexFacade`
 - Adds `ApiService::Yelp`
 - Renames `ApiService::GoogleGeocoding` to `ApiService::Google` (because it's used for both geocoding and directions)
 - Resolves several TODO's
 - Makes API error messages more specific -- passes on error messages from the API response