### PR TITLE
Cache forecasts & restaurants

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,35 @@ Things you may want to cover:
 * Ruby version: 2.4.1p111
 
 * System dependencies
+ - UNIX terminal
 
 * Configuration
- - `bundle`
+ - `$bundle`
+ - `$bundle exec figaro install`
+ - Add your own API keys to `config/application.yml`:
+ ```yml
+GOOGLE_MAPS_API_KEY: <your google maps API key>
+DARK_SKY_API_KEY: <your dark sky API key>
+FLICKR_API_KEY: <your flickr API key>
+FLICKR_SECRET: <your flickr secret>
+YELP_CLIENT_ID: <your yelp client ID>
+YELP_API_KEY: <your yelp API key>
+ ```
 
 * Database creation
- - `bundle exec rails db:create`
+ - `$bundle exec rails db:create`
 
 * Database initialization
- - `bundle exec rails db:migrate`
+ - `$bundle exec rails db:migrate`
 
 * How to run the test suite
- - `bundle exec rspec`
+ - `$bundle exec rspec`
 
 * Services (job queues, cache servers, search engines, etc.)
+ - To enable caching in the development environment, run `$rails dev:cache` once
 
 * Deployment instructions
+ - `$git push heroku master`
+ - Add ENV variables with `$heroku config:set <KEY>=<value>`
 
 * ...

--- a/app/controllers/api/v1/forecasts_controller.rb
+++ b/app/controllers/api/v1/forecasts_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::ForecastsController < ApplicationController
   def show
-    facade = ForecastShowFacade.new(params[:location])
+    location = params[:location]
+    facade = Rails.cache.fetch("forecasts/#{location}", expires_in: 1.minutes) do
+      ForecastShowFacade.new(location)
+    end
     render json: ForecastSerializer.new(facade).full_response
   end
 end

--- a/app/facades/munchies_index_facade.rb
+++ b/app/facades/munchies_index_facade.rb
@@ -52,7 +52,7 @@ class MunchiesIndexFacade
   
   def api_restaurants_hash
     begin
-      api_restaurants_hash ||= yelp_api.restaurants
+      @api_restaurants_hash ||= yelp_api.restaurants
     rescue
       { businesses: [] }
     end

--- a/app/services/api_service/dark_sky.rb
+++ b/app/services/api_service/dark_sky.rb
@@ -9,6 +9,7 @@ class ApiService::DarkSky < ApiService::Base
   def forecast
     uri_path = "/forecast/#{ENV['DARK_SKY_API_KEY']}/#{@lat},#{@long}"
     forecast_hash = fetch_json_data(uri_path)
+    Rails.logger.debug "Making Dark Sky forecast API call (#{@lat}-#{@long})"
     check_and_raise_error(forecast_hash)
     forecast_hash
   end

--- a/app/services/api_service/google.rb
+++ b/app/services/api_service/google.rb
@@ -9,6 +9,7 @@ class ApiService::Google < ApiService::Base
 
   def geocoding_results
     uri_path = '/maps/api/geocode/json'
+    Rails.logger.debug "Making Google geocoding API call (#{@location_string})"
     location_hash = fetch_json_data(uri_path, address: @location_string)
     check_and_raise_error(location_hash)
     location_hash
@@ -17,6 +18,7 @@ class ApiService::Google < ApiService::Base
   def directions
     uri_path = '/maps/api/directions/json'
     parameters = { origin: @origin, destination: @destination }
+    Rails.logger.debug "Making Google directions API call (#{@origin}-#{@destination})"
     directions_hash = fetch_json_data(uri_path, parameters)
     check_and_raise_error(directions_hash)
     directions_hash

--- a/app/services/api_service/yelp.rb
+++ b/app/services/api_service/yelp.rb
@@ -11,7 +11,7 @@ class ApiService::Yelp < ApiService::Base
     uri_path = '/v3/businesses/search'
     restaurants_hash = Rails.cache.fetch("restaurants/#{caching_params}", expires_in: 5.minutes) do
       Rails.logger.debug "Making Yelp restaurants API call (#{caching_params})"
-      restaurants_hash = fetch_json_data(uri_path, restaurant_search_params)
+      fetch_json_data(uri_path, restaurant_search_params)
     end
     check_and_raise_error(restaurants_hash)
     restaurants_hash

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,10 @@ Rails.application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
+  # Don't use caches for testing
+  config.action_controller.perform_caching = false 
+  config.cache_store = :null_store
+
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.


### PR DESCRIPTION
Minimize external API calls (related to #7, resolves #24) by caching...
 - Forecasts (for every location / every 1 minute)
 - Restaurants (for every location / 5 minute window / every 5 minutes)

Add logger.debug outputs on all external API calls to monitor them from the server logs

Disable caching in the test environment