### PR TITLE
Reduce external API calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem 'bcrypt'
 # Background worker
 gem 'sidekiq'
 
+# Automatically run jobs on a set interval
+gem 'simple_scheduler'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,9 @@ gem 'fast_jsonapi'
 # Enables has_secure_password
 gem 'bcrypt'
 
+# Background worker
+gem 'sidekiq'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem 'sidekiq'
 # Automatically run jobs on a set interval
 gem 'simple_scheduler'
 
+# Need Sinatra to view sidekiq dashboard
+gem 'sinatra'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,9 @@ GEM
       rack (>= 1.5.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    simple_scheduler (1.1.0)
+      rails (>= 4.2)
+      sidekiq (>= 4.2)
     simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -208,6 +211,7 @@ DEPENDENCIES
   rspec-rails
   shoulda-matchers
   sidekiq
+  simple_scheduler
   simplecov
   tzinfo-data
   vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     byebug (11.0.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -104,6 +105,8 @@ GEM
     public_suffix (3.1.1)
     puma (3.12.1)
     rack (2.0.7)
+    rack-protection (2.0.5)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -134,6 +137,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.2)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -155,6 +159,11 @@ GEM
     safe_yaml (1.0.5)
     shoulda-matchers (4.1.1)
       activesupport (>= 4.2.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -198,6 +207,7 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rspec-rails
   shoulda-matchers
+  sidekiq
   simplecov
   tzinfo-data
   vcr

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     minitest (5.11.3)
     msgpack (1.3.0)
     multipart-post (2.1.1)
+    mustermann (1.0.3)
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -172,6 +173,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -181,6 +187,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     vcr (5.0.0)
@@ -213,6 +220,7 @@ DEPENDENCIES
   sidekiq
   simple_scheduler
   simplecov
+  sinatra
   tzinfo-data
   vcr
   webmock

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ YELP_API_KEY: <your yelp API key>
 
 * Services (job queues, cache servers, search engines, etc.)
  - To enable caching in the development environment, run `$rails dev:cache` once
+ - In one terminal, run `$redis-server` (may need to do `$brew update && brew install redis` first)
+ - In another terminal, run `$bundle exec sidekiq`
 
 * Deployment instructions
  - `$git push heroku master`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ YELP_API_KEY: <your yelp API key>
  - To enable caching in the development environment, run `$rails dev:cache` once
  - In one terminal, run `$redis-server` (may need to do `$brew update && brew install redis` first)
  - In another terminal, run `$bundle exec sidekiq`
+ - Initiate the daily image database refresh by running `$rake simple_scheduler`
 
 * Deployment instructions
  - `$git push heroku master`

--- a/app/facades/background_show_facade.rb
+++ b/app/facades/background_show_facade.rb
@@ -4,7 +4,7 @@ class BackgroundShowFacade
   end
 
   def image_url
-    image = Image.find_by(title: @location_string)
+    image = Image.find_by(title: @location_string.downcase)
     if image
       image.url
     else

--- a/app/facades/background_show_facade.rb
+++ b/app/facades/background_show_facade.rb
@@ -8,8 +8,7 @@ class BackgroundShowFacade
     if image
       image.url
     else
-      # TODO: remove bang
-      image = Image.create!(
+      image = Image.create(
         title: @location_string, 
         url: flickr_api.image_url
       )

--- a/app/facades/background_show_facade.rb
+++ b/app/facades/background_show_facade.rb
@@ -4,7 +4,17 @@ class BackgroundShowFacade
   end
 
   def image_url
-    flickr_api.image_url
+    image = Image.find_by(title: @location_string)
+    if image
+      image.url
+    else
+      # TODO: remove bang
+      image = Image.create!(
+        title: @location_string, 
+        url: flickr_api.image_url
+      )
+      image.url
+    end
   end
 
   private

--- a/app/jobs/refresh_images_job.rb
+++ b/app/jobs/refresh_images_job.rb
@@ -1,0 +1,7 @@
+class RefreshImagesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Image.destroy_all
+  end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,5 @@
+class Image < ApplicationRecord
+  validates :title, uniqueness: { case_sensitive: false }, presence: true
+
+  before_save { self.title = self.title.to_s.downcase }
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,8 @@ module SweaterWeather
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Use sidekiq gem as background worker
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  mount Sidekiq::Web => '/sidekiq'
 
   namespace :api do
     namespace :v1 do

--- a/config/simple_scheduler.yml
+++ b/config/simple_scheduler.yml
@@ -1,0 +1,31 @@
+# Global configuration options. The `queue_ahead` and `tz` options can also be set on each task.
+queue_ahead: 360 # Number of minutes to queue jobs into the future
+queue_name: "default" # The Sidekiq queue name used by SimpleScheduler::FutureJob
+tz: "America/Denver" # The application time zone will be used by default if not set
+
+# # Runs once every 2 minutes starting at the top of the hour
+# simple_task:
+#   class: "SomeActiveJob"
+#   every: "2.minutes"
+#   at: "*:00"
+
+# Runs once every day at 4:00 AM. The job will expire after 23 hours, which means the
+# job will not run if 23 hours passes (server downtime) before the job is actually run
+overnight_task:
+  class: "RefreshImagesJob"
+  every: "1.day"
+  at: "4:00"
+  expires_after: "23.hours"
+
+# # Runs once every half hour, starting on the 30 min mark
+# half_hour_task:
+#   class: "HalfHourTask"
+#   every: "30.minutes"
+#   at: "*:30"
+
+# # Runs once every week on Saturdays at 12:00 AM
+# weekly_task:
+#   class: "WeeklyJob"
+#   every: "1.week"
+#   at: "Sat 0:00"
+#   tz: "America/New_York"

--- a/db/migrate/20190730231701_create_images.rb
+++ b/db/migrate/20190730231701_create_images.rb
@@ -1,0 +1,10 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.string :title
+      t.string :url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_29_181423) do
+ActiveRecord::Schema.define(version: 2019_07_30_231701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "images", force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email"

--- a/spec/cassettes/backgrounds_endpoint/minimize_api_calls.yml
+++ b/spec/cassettes/backgrounds_endpoint/minimize_api_calls.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.flickr.com/services/rest?api_key=<FLICKR_API_KEY>&content=relevance&method=flickr.photos.search&per_page=1&sort=relevance&tags=downtown&text=denver,co
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/xml; charset=utf-8
+      Content-Length:
+      - '255'
+      Connection:
+      - keep-alive
+      Date:
+      - Tue, 30 Jul 2019 23:22:48 GMT
+      Server:
+      - Apache/2.4.39 (Ubuntu)
+      X-Robots-Tag:
+      - noindex
+      Vary:
+      - Accept-Encoding
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 3548a9f5c122b933c8723d4f2b818c3f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - ORD52-C2
+      X-Amz-Cf-Id:
+      - NsRGTXCw18A341QDK1MjD-W2OwT-OcGdQjy0YfCUw8co_U5ymQBA6g==
+    body:
+      encoding: ASCII-8BIT
+      string: "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n<rsp stat=\"ok\">\n<photos
+        page=\"1\" pages=\"107\" perpage=\"1\" total=\"107\">\n\t<photo id=\"3467379196\"
+        owner=\"75081971@N00\" secret=\"5e20d8b818\" server=\"3621\" farm=\"4\" title=\"INVESCOFIELD_URBAN
+        LANDSCAPE_GREGTHOW\" ispublic=\"1\" isfriend=\"0\" isfamily=\"0\" />\n</photos>\n</rsp>\n"
+    http_version: 
+  recorded_at: Tue, 30 Jul 2019 23:22:47 GMT
+recorded_with: VCR 5.0.0

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :image do
+    sequence(:title) { |n| "image_title_#{n}" }
+    sequence(:url) { |n| "image_url_#{n}.jpg" }
+  end
+end

--- a/spec/jobs/refresh_images_job_spec.rb
+++ b/spec/jobs/refresh_images_job_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe RefreshImagesJob, type: :job do
+  it 'destroys all image resources' do
+    create_list(:image, 2)
+    
+    expect(Image.count).to eq(2)
+
+    RefreshImagesJob.perform_now
+
+    expect(Image.count).to eq(0)
+  end
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe Image, type: :model do
+  describe 'validations' do
+    it { should validate_uniqueness_of(:title).case_insensitive }
+    it { should validate_presence_of :title }
+  end
+  
+  it 'automatically makes titles lowercase' do
+    title = 'Denver, CO'
+    image = create(:image, title: title)
+  
+    expect(image.title).to eq(title.downcase)
+  end
+end

--- a/spec/requests/api/v1/backgrounds_spec.rb
+++ b/spec/requests/api/v1/backgrounds_spec.rb
@@ -21,8 +21,8 @@ describe "Backgrounds Endpoint" do
 
       expect(response).to be_successful
       expect(Image.count).to eq(1)
-      
-      get '/api/v1/backgrounds?location=denver,co'
+
+      get '/api/v1/backgrounds?location=DENVER,co'
 
       expect(response).to be_successful
       expect(Image.count).to eq(1)

--- a/spec/requests/api/v1/backgrounds_spec.rb
+++ b/spec/requests/api/v1/backgrounds_spec.rb
@@ -12,4 +12,24 @@ describe "Backgrounds Endpoint" do
       expect(data).to have_key(:url)
     end
   end
+
+  it "doesn't make another API call if the same city has already been searched for" do
+    VCR.use_cassette('backgrounds_endpoint/minimize_api_calls', record: :new_episodes) do
+      expect(Image.count).to eq(0)
+
+      get '/api/v1/backgrounds?location=denver,co'
+
+      expect(response).to be_successful
+      expect(Image.count).to eq(1)
+      
+      get '/api/v1/backgrounds?location=denver,co'
+
+      expect(response).to be_successful
+      expect(Image.count).to eq(1)
+
+      data = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(data).to have_key(:url)
+    end
+  end
 end


### PR DESCRIPTION
This branch...
 - Adds an `Image` model / table / factory
 - Adds the following gems: 
    - `sidekiq` (background worker)
    - `simple_scheduler` (automatically runs designated jobs on a designated schedule)
    - `sinatra` (to view the sidekiq dashboard)
 - Adds `RefreshImagesJob` -- destroys all images once a day
 - Changes `BackgroundShowFacade#image_url` to only make an external API call to Flickr if the `images` table doesn't already have an image for the city

Reduces external API calls -- resolves #7 & resolves #23